### PR TITLE
Fix to cross-compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker build -t disco-builder -f ci/Dockerfile.debian ci/
 ```console
 $ mkdir build-armv7
 $ docker run -it -v .:/src disco-builder meson setup --cross-file /opt/arm-buildroot-linux-gnueabihf_sdk-buildroot/etc/meson/cross-compilation.conf build-armv7
-$ docker run -it -v .:/src ninja -C build-armv7
+$ docker run -it -v .:/src disco-builder ninja -C build-armv7
 ```
 
 If you prefer, you can also copy the toolchain off the container and just use it in your

--- a/ci/Dockerfile.debian
+++ b/ci/Dockerfile.debian
@@ -38,8 +38,11 @@ RUN apt update && apt install -y \
 	gcc \
 	python3-pip \
 	qemu-user-static \
+        ninja-build \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir -p /src
 RUN pip3 install meson
+# If meson cannot find the right ninja version, the solution is to uninstall the ninja that came with meson: https://github.com/rizinorg/cutter/issues/2733
+RUN pip3 uninstall ninja
 WORKDIR /src
 COPY --from=builder /opt /opt


### PR DESCRIPTION
there is no ninja:latest image as of 2023, so it makes sense to use the ninja inside the disco-builder image.

The ninja that comes with meson is apparently outdated however, so we uninstall it via pip and install a newer compatible ninja from the ninja-build package